### PR TITLE
Use upstream libhybris/stable from launchpad to match rootfs version

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -6,6 +6,10 @@
 	review="http://code-review.phablet.ubuntu.com"
 	revision="refs/tags/android-5.1.1_r5" />
 
+  <remote name="launchpad"
+        fetch="https://git.launchpad.net/~libhybris-maintainers/libhybris/+git/"
+        revision="stable" />
+
   <remote  name="aosp"
            fetch="https://android.googlesource.com"
            review="android-review.googlesource.com"
@@ -205,7 +209,7 @@
   <project path="external/koush/Superuser" name="CyanogenMod/Superuser" revision="refs/heads/cm-12.0"/>
   <project path="external/gpg" name="aosp/platform/external/gpg" revision="refs/heads/master" />
   <project path="ubuntu/assets" name="ubuntu/assets" revision="refs/heads/master" />
-  <project path="ubuntu/libhybris" name="ubports/libhybris" remote="ubp" />
+  <project path="ubuntu/libhybris" name="libhybris" remote="launchpad" />
   <project path="ubuntu/platform-api" name="ubuntu/platform-api" revision="refs/heads/personal/w-ondra/phablet-5.x" />
   <project path="ubuntu/upstart-property-watcher" name="ubuntu/upstart-property-watcher" revision="refs/heads/personal/w-ondra/phablet-5.x" />
 


### PR DESCRIPTION
Track upstream's libhybris stable branch to guarantee no ABI breaks with what goes in the distro packages.

Change-Id: Ibc50b1e89c9ff96bc0eac66e66bd299f922b5381